### PR TITLE
add jsr prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ deno init
 3\. Add `@fartlabs/rtx` as a project dependency.
 
 ```sh
-deno add @fartlabs/rtx
+deno add jsr:@fartlabs/rtx
 ```
 
 4\. Add the following values to your `deno.json(c)` file.


### PR DESCRIPTION
Add the `jsr:` prefix when adding `rtx` to the project now that [it's on jsr](https://jsr.io/@fartlabs/rtx). Plus, Deno will complain if you don't add it.